### PR TITLE
change entity list to ignore player when pasting

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/object/schematic/Schematic.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/schematic/Schematic.java
@@ -274,6 +274,10 @@ public class Schematic {
         final int entityOffsetZ = to.getBlockZ() - origin.getBlockZ();
         // entities
         for (Entity entity : clipboard.getEntities()) {
+            // skip players on pasting schematic
+            if (entity.getState() != null && entity.getState().getType().getId().equals("minecraft:player")) {
+                continue;
+            }
             Location pos = entity.getLocation();
             Location newPos = new Location(pos.getExtent(), pos.getX() + entityOffsetX, pos.getY() + entityOffsetY, pos.getZ() + entityOffsetZ, pos.getYaw(), pos.getPitch());
             extent.createEntity(newPos, entity.getState());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -50,7 +50,7 @@ import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.regions.Region;
 import java.util.ArrayList;
 import java.util.List;
-
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -347,7 +347,18 @@ public class ForwardExtentCopy implements Operation {
             blockCopy = new RegionVisitor(region, copy, queue instanceof MappedFaweQueue ? (MappedFaweQueue) queue : null);
         }
 
-        List<? extends Entity> entities = isCopyingEntities() ? source.getEntities(region) : new ArrayList<>();
+        List<? extends Entity> entities;
+        if (isCopyingEntities()) {
+            // filter players since they can't be copied
+            entities = source.getEntities()
+                    .stream()
+                    .filter(entity -> entity.getState() != null &&
+                            entity.getState().getType().getId().equals("minecraft:player"))
+                    .collect(Collectors.toList());
+        } else {
+            entities = new ArrayList<>();
+        }
+
 
         for (int i = 0; i < repetitions; i++) {
             Operations.completeBlindly(blockCopy);


### PR DESCRIPTION
I decided to stay with the stream construction because the list type is a wildcard, means we would either need to change that or to add a helper method (or use an Iterator to remove players).
Commits should be fine now too...