### PR TITLE
fix //removenear exception for size < 1

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -366,6 +366,7 @@ public class UtilityCommands extends MethodCommands {
     @Logging(PLACEMENT)
     public void removeNear(Player player, LocalSession session, EditSession editSession, Mask mask, @Optional("50") double size) throws WorldEditException {
         worldEdit.checkMaxRadius(size);
+        size = Math.max(1, size);
         int affected = editSession.removeNear(session.getPlacementPosition(player), mask, (int) size);
         player.print(BBC.getPrefix() + affected + " block(s) have been removed.");
     }


### PR DESCRIPTION
This change will avoid the exception which was thrown for sizes less than 1.It now just set the size to 1 if it is less than 1. It won't remove any block as long as you aren't inside of the block.
I've adapted this from WE's code.