### PR TITLE
fix NPE when reading sponge schematics with tile entities or entities

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
@@ -210,6 +210,7 @@ public class SpongeSchematicReader extends NBTSchematicReader {
         });
         streamer.readFully();
         if (fc == null) setupClipboard(length * width * height, uuid);
+        else fc.setDimensions(new Vector(width, height, length));
         Vector origin = min;
         CuboidRegion region;
         if (offsetX != Integer.MIN_VALUE && offsetY != Integer.MIN_VALUE  && offsetZ != Integer.MIN_VALUE) {
@@ -242,7 +243,6 @@ public class SpongeSchematicReader extends NBTSchematicReader {
                 }
             }
         }
-        fc.setDimensions(new Vector(width, height, length));
         clipboard.init(region, fc);
         clipboard.setOrigin(origin);
         return clipboard;


### PR DESCRIPTION
Fixes this error when trying to read a sponge schematic that contains tile entities or entities:
https://pastebin.com/um0ax14N

The NPE was thrown because the clipboard is initialized with size == 0 and only resized after setting the blocks, if any tile entities or entities exist in the schematic.
This does fix the CPUOptimizedClipboard and DiskOptimizedClipboard, the MemoryOptimizedClipboard is still fucked and stores random blocks.