### PR TITLE
Fix sponge schematics not correctly setting dimensions if there are no entities

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
@@ -210,7 +210,7 @@ public class SpongeSchematicReader extends NBTSchematicReader {
         });
         streamer.readFully();
         if (fc == null) setupClipboard(length * width * height, uuid);
-        else fc.setDimensions(new Vector(width, height, length));
+        fc.setDimensions(new Vector(width, height, length));
         Vector origin = min;
         CuboidRegion region;
         if (offsetX != Integer.MIN_VALUE && offsetY != Integer.MIN_VALUE  && offsetZ != Integer.MIN_VALUE) {


### PR DESCRIPTION
Minor but important improvement to  #35 

With the 'else' statement here, if the schematic contains no entities or tile entities the dimensions of the schematic are never set, causing it to load as a nx1x1 column of blocks (which might be *very* long)

Tested this a fair amount, seems to work well. 