### PR TITLE
(dirty) Fix for VaultAPI build issue

### DIFF
--- a/worldedit-bukkit/build.gradle
+++ b/worldedit-bukkit/build.gradle
@@ -8,11 +8,11 @@ repositories {
 
 dependencies {
     compile project(':worldedit-core')
+    compile 'net.milkbowl.vault:VaultAPI:1.7'
     compile 'com.sk89q:dummypermscompat:1.8'
     compile 'com.destroystokyo.paper:paper-api:1.13.2-R0.1-SNAPSHOT'
     compile 'org.spigotmc:spigot:1.13.2-R0.1-SNAPSHOT'
     testCompile 'org.mockito:mockito-core:1.9.0-rc1'
-    compile 'net.milkbowl.vault:VaultAPI:1.7'
     compile 'com.massivecraft:factions:2.8.0'
     compile 'com.drtshock:factions:1.6.9.5'
     compile 'com.factionsone:FactionsOne:1.2.2'


### PR DESCRIPTION
As discuseed in Discord, placing the Vault-API Dependency over the dummypermscompat fixes the compiling issue, even though this is still a sketchy issue