### PR TITLE
Fix Java 12+ compatibility

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_13/BukkitAdapter_1_13.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_13/BukkitAdapter_1_13.java
@@ -7,6 +7,7 @@ import com.boydti.fawe.bukkit.adapter.NMSAdapter;
 import com.boydti.fawe.config.Settings;
 import com.boydti.fawe.object.collection.BitArray4096;
 import com.boydti.fawe.util.MathMan;
+import com.boydti.fawe.util.ReflectionUtils;
 import com.boydti.fawe.util.TaskManager;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
@@ -83,11 +84,7 @@ public final class BukkitAdapter_1_13 extends NMSAdapter {
                 } catch (NoSuchFieldException paper) {
                     tmp = DataPaletteBlock.class.getDeclaredField("j");
                 }
-                Field modifiersField = Field.class.getDeclaredField("modifiers");
-                modifiersField.setAccessible(true);
-                int modifiers = modifiersField.getInt(tmp);
-                int newModifiers = modifiers & (~Modifier.FINAL);
-                if (newModifiers != modifiers) modifiersField.setInt(tmp, newModifiers);
+                ReflectionUtils.setAccessibleNonFinal(tmp);
                 fieldLock = tmp;
                 fieldLock.setAccessible(true);
             }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_14/BukkitAdapter_1_14.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_14/BukkitAdapter_1_14.java
@@ -7,6 +7,7 @@ import com.boydti.fawe.bukkit.adapter.DelegateLock;
 import com.boydti.fawe.config.Settings;
 import com.boydti.fawe.object.collection.BitArray4096;
 import com.boydti.fawe.util.MathMan;
+import com.boydti.fawe.util.ReflectionUtils;
 import com.boydti.fawe.util.TaskManager;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
@@ -83,11 +84,7 @@ public final class BukkitAdapter_1_14 extends NMSAdapter {
                 } catch (NoSuchFieldException paper) {
                     tmp = DataPaletteBlock.class.getDeclaredField("j");
                 }
-                Field modifiersField = Field.class.getDeclaredField("modifiers");
-                modifiersField.setAccessible(true);
-                int modifiers = modifiersField.getInt(tmp);
-                int newModifiers = modifiers & (~Modifier.FINAL);
-                if (newModifiers != modifiers) modifiersField.setInt(tmp, newModifiers);
+                ReflectionUtils.setAccessibleNonFinal(tmp);
                 fieldLock = tmp;
                 fieldLock.setAccessible(true);
             }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BukkitAdapter_1_15.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BukkitAdapter_1_15.java
@@ -7,6 +7,7 @@ import com.boydti.fawe.bukkit.adapter.NMSAdapter;
 import com.boydti.fawe.config.Settings;
 import com.boydti.fawe.object.collection.BitArray4096;
 import com.boydti.fawe.util.MathMan;
+import com.boydti.fawe.util.ReflectionUtils;
 import com.boydti.fawe.util.TaskManager;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
@@ -18,7 +19,6 @@ import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.Lock;
@@ -66,11 +66,7 @@ public final class BukkitAdapter_1_15 extends NMSAdapter {
             fieldDirtyBits.setAccessible(true);
 
             Field tmp = DataPaletteBlock.class.getDeclaredField("j");
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            int modifiers = modifiersField.getInt(tmp);
-            int newModifiers = modifiers & (~Modifier.FINAL);
-            if (newModifiers != modifiers) modifiersField.setInt(tmp, newModifiers);
+            ReflectionUtils.setAccessibleNonFinal(tmp);
             fieldLock = tmp;
             fieldLock.setAccessible(true);
 

--- a/worldedit-core/src/main/java/com/boydti/fawe/object/collection/LocalBlockVector2DSet.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/collection/LocalBlockVector2DSet.java
@@ -141,7 +141,7 @@ public class LocalBlockVector2DSet implements Set<BlockVector2> {
 
     @Override
     public Object[] toArray() {
-        return toArray(null);
+        return toArray((Object[]) null);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/boydti/fawe/object/collection/LocalBlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/collection/LocalBlockVectorSet.java
@@ -160,7 +160,7 @@ public class LocalBlockVectorSet implements Set<BlockVector3> {
 
     @NotNull @Override
     public Object[] toArray() {
-        return toArray(null);
+        return toArray((Object[]) null);
     }
 
     @NotNull @Override

--- a/worldedit-core/src/main/java/com/boydti/fawe/util/ReflectionUtils9.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/util/ReflectionUtils9.java
@@ -2,7 +2,10 @@ package com.boydti.fawe.util;
 
 import sun.misc.Unsafe;
 
-import java.lang.reflect.*;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,15 +44,15 @@ public class ReflectionUtils9 {
 
             // 5. Set new values field
             try {
-                setFailsafeFieldValue(valuesField, null,
+                ReflectionUtils.setFailsafeFieldValue(valuesField, null,
                         values.toArray((T[]) Array.newInstance(enumType, 0)));
             } catch (Throwable e) {
                 Field ordinalField = Enum.class.getDeclaredField("ordinal");
-                setFailsafeFieldValue(ordinalField, newValue, 0);
+                ReflectionUtils.setFailsafeFieldValue(ordinalField, newValue, 0);
             }
 
             // 6. Clean enum cache
-            cleanEnumCache(enumType);
+            ReflectionUtils.cleanEnumCache(enumType);
             return newValue;
         } catch (Exception e) {
             e.printStackTrace();
@@ -64,55 +67,11 @@ public class ReflectionUtils9 {
         Object instance = unsafe.allocateInstance(enumClass);
 
         Field ordinalField = Enum.class.getDeclaredField("ordinal");
-        setFailsafeFieldValue(ordinalField, instance, 0);
+        ReflectionUtils.setFailsafeFieldValue(ordinalField, instance, 0);
 
         Field nameField = Enum.class.getDeclaredField("name");
-        setFailsafeFieldValue(nameField, instance, value);
+        ReflectionUtils.setFailsafeFieldValue(nameField, instance, value);
 
         return instance;
-    }
-
-    public static void setFailsafeFieldValue(Field field, Object target, Object value)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        // let's make the field accessible
-        field.setAccessible(true);
-
-        // next we change the modifier in the Field instance to
-        // not be final anymore, thus tricking reflection into
-        // letting us modify the static final field
-        if (Modifier.isFinal(field.getModifiers())) {
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            int modifiers = modifiersField.getInt(field);
-
-            // blank out the final bit in the modifiers int
-            modifiers &= ~Modifier.FINAL;
-            modifiersField.setInt(field, modifiers);
-        }
-
-        try {
-            if (target == null) field.set(null, value);
-            else field.set(target, value);
-        } catch (NoSuchMethodError error) {
-            field.set(target, value);
-        }
-    }
-
-    private static void blankField(Class<?> enumClass, String fieldName)
-            throws NoSuchFieldException, IllegalAccessException {
-        for (Field field : Class.class.getDeclaredFields()) {
-            if (field.getName().contains(fieldName)) {
-                AccessibleObject.setAccessible(new Field[]{field}, true);
-                setFailsafeFieldValue(field, enumClass, null);
-                break;
-            }
-        }
-    }
-
-    private static void cleanEnumCache(Class<?> enumClass)
-            throws NoSuchFieldException, IllegalAccessException {
-        blankField(enumClass, "enumConstantDirectory"); // Sun (Oracle?!?) JDK 1.5/6
-        blankField(enumClass, "enumConstants"); // IBM JDK
     }
 }


### PR DESCRIPTION
## Description
This pr fixes Java 12+ compatibility due to the modifiers field being hidden in (standard) reflection methods.
Tested this on a Java 8, 9, and 13 server.

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines] (kinda, since they don't exist)(https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/breaking/CONTRIBUTING.md)
