### PR TITLE
Improve security of hash verification

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/util/Jars.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/util/Jars.java
@@ -13,11 +13,11 @@ public enum Jars {
 
     MM_v1_7_3(
         "https://github.com/InventivetalentDev/MapManager/releases/download/1.7.3-SNAPSHOT/MapManager_v1.7.3-SNAPSHOT.jar",
-        "M3YLUQZZ66K2DMVDCYLEU38U3ZKRKHRAXQGGPVKFO6G=", 554831),
+        "m3YLUqZz66k2DmvdcYLeu38u3zKRKhrAXqGGpVKfO6g=", 554831),
 
     PL_v3_7_3(
         "https://github.com/InventivetalentDev/PacketListenerAPI/releases/download/3.7.3-SNAPSHOT/PacketListenerAPI_v3.7.3-SNAPSHOT.jar",
-        "ETDBRZLN5PRVDFR/MSQDPM6JJER3WQOKHCN8FUXO5ZM=", 167205),
+        "etdBRzLn5pRVDfr/mSQdPm6Jjer3wQOKhcn8fUxo5zM=", 167205),
 
     ;
 
@@ -27,12 +27,12 @@ public enum Jars {
 
     /**
      * @param url Where this jar can be found and downloaded
-     * @param digest The SHA-256 hexadecimal digest
+     * @param digest The Base64-encoded SHA-256 digest
      * @param fileSize Size of this jar in bytes
      */
     Jars(String url, String digest, int fileSize) {
         this.url = url;
-        this.digest = digest.toUpperCase();
+        this.digest = digest;
         this.fileSize = fileSize;
     }
 
@@ -50,7 +50,7 @@ public enum Jars {
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] jarDigestBytes = md.digest(jarBytes);
 
-            String jarDigest = Base64.getEncoder().encodeToString(jarDigestBytes).toUpperCase();
+            String jarDigest = Base64.getEncoder().encodeToString(jarDigestBytes);
 
             if (this.digest.equals(jarDigest)) {
                 getLogger(Jars.class).debug("++++ HASH CHECK ++++");


### PR DESCRIPTION
## Overview
At some point, the code for integrity checks of downloaded JAR files has been changed to use the Base64 hash digest representation rather than the hexadecimal representation. However, `.toUpperCase()` has been left in place, now ignoring the proper casing of the Base64 representation.
This is a bad idea because makes hashes easier to break/collide as a variety of potential SHA-256 digests match a case-*insensitive* Base64 representation.

## Description
I changed Jars.java to take the casing into account and updated the included digests with their correct casing. This makes the hash verification more secure. <sub>And while at it, I made sure to update the javadoc which still referred to hexadecimal digests.</sub>

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
